### PR TITLE
feat: Add signature TLV parsing helper

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { Ethereum } from "./ethereum.ts"
 import { KeyPath } from "./key-path.ts"
 import { Mnemonic } from "./mnemonic.ts"
 import { RecoverableSignature } from "./recoverable-signature.ts"
+import { Signature } from "./signature.ts"
 import { PCSCCardChannel } from "./pcsc-card-channel.ts"
 import { CryptoUtils } from "./crypto-utils.ts"
 import { Constants } from "./constants.ts"
@@ -38,6 +39,7 @@ export let Keycard = {
   KeyPath: KeyPath,
   Mnemonic: Mnemonic,
   RecoverableSignature: RecoverableSignature,
+  Signature: Signature,
   Certificate: Certificate,
   PCSCCardChannel: PCSCCardChannel,
   Ethereum: Ethereum,
@@ -48,5 +50,5 @@ export let Keycard = {
   KeycardEventEmitter: KeycardEventEmitter
 }
 
-export { RecoverableSignatureTypes, PairingStorage, Callback, Subscription, ParsedTLV };
+export { Signature, RecoverableSignatureTypes, PairingStorage, Callback, Subscription, ParsedTLV };
 export default Keycard;

--- a/src/signature.ts
+++ b/src/signature.ts
@@ -1,0 +1,72 @@
+import { BERTLV } from "./ber-tlv.ts";
+import { Constants } from "./constants.ts";
+import { CryptoUtils } from "./crypto-utils.ts";
+import { RecoverableSignature } from "./recoverable-signature.ts";
+
+const SIGNATURE_SCALAR_BYTES = 32;
+
+export type ParsedSignatureTLV = {
+  publicKey: Uint8Array;
+  compressedPublicKey: Uint8Array;
+  r: Uint8Array;
+  s: Uint8Array;
+  compactSignature: Uint8Array;
+};
+
+export type ParsedRecoverableSignatureTLV = ParsedSignatureTLV & {
+  recId: number;
+};
+
+export namespace Signature {
+  export function normalizeScalar(bytes: Uint8Array): Uint8Array {
+    const stripped = bytes[0] === 0x00 ? bytes.slice(1) : bytes;
+
+    if (stripped.length > SIGNATURE_SCALAR_BYTES) {
+      throw new Error("Error: Signature scalar is too large");
+    }
+
+    if (stripped.length === SIGNATURE_SCALAR_BYTES) {
+      return stripped;
+    }
+
+    const padded = new Uint8Array(SIGNATURE_SCALAR_BYTES);
+    padded.set(stripped, SIGNATURE_SCALAR_BYTES - stripped.length);
+    return padded;
+  }
+
+  export function parseTLV(tlvData: Uint8Array): ParsedSignatureTLV {
+    const tlv = new BERTLV(tlvData);
+    tlv.enterConstructed(Constants.TLV_SIGNATURE_TEMPLATE);
+
+    const publicKey = tlv.readPrimitive(Constants.TLV_PUB_KEY);
+    tlv.enterConstructed(Constants.TLV_ECDSA_TEMPLATE);
+
+    const r = normalizeScalar(tlv.readPrimitive(Constants.TLV_INT));
+    const s = normalizeScalar(tlv.readPrimitive(Constants.TLV_INT));
+
+    const compactSignature = new Uint8Array(2 * SIGNATURE_SCALAR_BYTES);
+    compactSignature.set(r, 0);
+    compactSignature.set(s, SIGNATURE_SCALAR_BYTES);
+
+    return {
+      publicKey,
+      compressedPublicKey: CryptoUtils.compressPublicKey(publicKey),
+      r,
+      s,
+      compactSignature,
+    };
+  }
+
+  export function parseRecoverableTLV(
+    hash: Uint8Array,
+    tlvData: Uint8Array,
+  ): ParsedRecoverableSignatureTLV {
+    const parsed = parseTLV(tlvData);
+    const recoverable = new RecoverableSignature({ hash, tlvData });
+
+    return {
+      ...parsed,
+      recId: recoverable.recId!,
+    };
+  }
+}

--- a/test/signature.test.ts
+++ b/test/signature.test.ts
@@ -1,0 +1,70 @@
+import { sha256 } from "@noble/hashes/sha2";
+import { hmac } from "@noble/hashes/hmac";
+import * as secp from "@noble/secp256k1";
+
+import { CryptoUtils } from "../src/crypto-utils";
+import { Signature } from "../src/signature";
+
+const privateKey = new Uint8Array([
+  186, 240, 247, 237, 145, 53, 118, 68,
+  96, 251, 38, 229, 65, 202, 162, 134,
+  6, 118, 195, 23, 79, 43, 94, 54,
+  100, 177, 162, 242, 73, 105, 48, 83,
+]);
+
+secp.hashes.sha256 = sha256;
+secp.hashes.hmacSha256 = (key, msg) => hmac(sha256, key, msg);
+
+const hash = sha256(new TextEncoder().encode("keycard-signature-test"));
+const publicKey = secp.getPublicKey(privateKey, false);
+const signature = secp.sign(hash, privateKey, { format: "recovered", prehash: false });
+const r = signature.subarray(1, 33);
+const s = signature.subarray(33, 65);
+
+function encodeInteger(bytes: Uint8Array, addLeadingZero = false): number[] {
+  const normalized = addLeadingZero ? new Uint8Array([0x00, ...bytes]) : bytes;
+  return [0x02, normalized.length, ...normalized];
+}
+
+function buildSignatureTLV(args?: { addLeadingZeroToR?: boolean; addLeadingZeroToS?: boolean }): Uint8Array {
+  const ecdsa = [
+    ...encodeInteger(r, args?.addLeadingZeroToR),
+    ...encodeInteger(s, args?.addLeadingZeroToS),
+  ];
+
+  return new Uint8Array([
+    0xa0,
+    2 + publicKey.length + 2 + ecdsa.length,
+    0x80,
+    publicKey.length,
+    ...publicKey,
+    0x30,
+    ecdsa.length,
+    ...ecdsa,
+  ]);
+}
+
+test("Signature.parseTLV returns normalized signature fields", () => {
+  const tlv = buildSignatureTLV({ addLeadingZeroToR: true, addLeadingZeroToS: true });
+  const parsed = Signature.parseTLV(tlv);
+
+  expect(parsed.publicKey).toEqual(publicKey);
+  expect(parsed.compressedPublicKey).toEqual(CryptoUtils.compressPublicKey(publicKey));
+  expect(parsed.r).toEqual(r);
+  expect(parsed.s).toEqual(s);
+  expect(parsed.compactSignature).toEqual(new Uint8Array([...r, ...s]));
+});
+
+test("Signature.parseRecoverableTLV returns recId compatible with the signature hash", () => {
+  const tlv = buildSignatureTLV();
+  const parsed = Signature.parseRecoverableTLV(hash, tlv);
+
+  expect(parsed.recId).toBe(signature[0]);
+  expect(parsed.compactSignature).toEqual(new Uint8Array([...r, ...s]));
+});
+
+test("Signature.normalizeScalar rejects scalars longer than 32 bytes", () => {
+  expect(() => Signature.normalizeScalar(new Uint8Array(33).fill(1))).toThrow(
+    "Error: Signature scalar is too large",
+  );
+});


### PR DESCRIPTION
## Summary

Adds a reusable SDK helper for parsing Keycard signature TLV payloads.

GapSign currently duplicates this parsing logic in its Bitcoin and Ethereum signing utilities. The repeated pieces are the same:

- read the Keycard signature TLV structure;
- extract the embedded public key;
- normalize DER integer scalars to 32 bytes;
- build the compact `r || s` form;
- recover `recId` when a message hash is available.

This change introduces a shared `Signature` helper in the SDK so app code can reuse the parsing logic without reimplementing the TLV details.

## Changes

- add `src/signature.ts`
- expose `Signature.parseTLV(tlvData)`
- expose `Signature.parseRecoverableTLV(hash, tlvData)`
- expose `Signature.normalizeScalar(bytes)`
- export `Signature` via both the default `Keycard` namespace and the package root exports in `src/index.ts`

The helper returns:

- raw public key
- compressed public key
- normalized `r`
- normalized `s`
- compact `r || s`
- `recId` when a hash is provided

## Example

```ts
import Keycard from "keycard-sdk";

const signResp = await cmdSet.signWithPath(hash, "m/44'/60'/0'/0/0", false);
signResp.checkOK();

const parsed = Keycard.Signature.parseRecoverableTLV(hash, signResp.data);

const compressedPublicKey = parsed.compressedPublicKey;
const compactSignature = parsed.compactSignature;
const recId = parsed.recId;
```

## Verification

- `npm run build`
- `npm test -- --runInBand`

Both pass locally.